### PR TITLE
fix: disable dependabot alerts on python 3.13

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,9 @@ updates:
     labels:
       - "dependencies"
       - "docker"
+    ignore:
+      - dependency-name: "python"
+        versions: ["3.13", "3.13.*"]
 
   # Python dependencies (backend folder)
   - package-ecosystem: "pip"


### PR DESCRIPTION
## What does this PR do?

Adds ignore rule to prevent dependabot from creating PRs for Python 3.13 updates, keeping the project on Python 3.12.

**Changes:**
- Added `ignore` section to `.github/dependabot.yml`
- Ignores `python` version `3.13` and `3.13.*`

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Other

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (if applicable)

## Related issue

https://github.com/narevai/narev/pull/2
