### PR TITLE
fix: remove Dockerfile layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,8 @@
 FROM node:24-alpine AS frontend-build
 WORKDIR /app/frontend
 RUN npm install -g pnpm
-COPY frontend/package.json frontend/pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile
 COPY frontend/ ./
+RUN pnpm install --frozen-lockfile
 RUN pnpm run build
 
 ######## Backend Production Stage ########


### PR DESCRIPTION
## What does this PR do?

Docker builds were failing with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` due to a subtle issue in the two-stage file copying approach.

**Root Cause:**
The Dockerfile was copying `package.json` twice:
1. First copy: `COPY frontend/package.json frontend/pnpm-lock.yaml ./`
2. Install: `RUN pnpm install --frozen-lockfile` 
3. Second copy: `COPY frontend/ ./` ← This overwrote the package.json used for install

This created a state inconsistency that pnpm detected as a configuration mismatch, even though the files were identical.

**Solution:**
Simplified the frontend build stage to use a single copy operation.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Tests added/updated (if applicable)
